### PR TITLE
Support OpenReadWrite to match pebble vfs iface

### DIFF
--- a/error_fs.go
+++ b/error_fs.go
@@ -156,6 +156,22 @@ func (fs *ErrorFS) Open(name string, opts ...OpenOption) (File, error) {
 	return ef, nil
 }
 
+// OpenReadWrite implements FS.OpenReadWrite.
+func (fs *ErrorFS) OpenReadWrite(name string, opts ...OpenOption) (File, error) {
+	if err := fs.inj.MaybeError(OpRead); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.OpenReadWrite(name)
+	if err != nil {
+		return nil, err
+	}
+	ef := &errorFile{f, fs.inj}
+	for _, opt := range opts {
+		opt.Apply(ef)
+	}
+	return ef, nil
+}
+
 // OpenDir implements FS.OpenDir.
 func (fs *ErrorFS) OpenDir(name string) (File, error) {
 	if err := fs.inj.MaybeError(OpRead); err != nil {

--- a/mem_fs.go
+++ b/mem_fs.go
@@ -38,22 +38,23 @@ func NewMem() *MemFS {
 // at which point they are discarded and no longer visible.
 //
 // Expected usage:
-//  strictFS := NewStrictMem()
-//  db := Open(..., &Options{FS: strictFS})
-//  // Do and commit various operations.
-//  ...
-//  // Prevent any more changes to finalized state.
-//  strictFS.SetIgnoreSyncs(true)
-//  // This will finish any ongoing background flushes, compactions but none of these writes will
-//  // be finalized since syncs are being ignored.
-//  db.Close()
-//  // Discard unsynced state.
-//  strictFS.ResetToSyncedState()
-//  // Allow changes to finalized state.
-//  strictFS.SetIgnoreSyncs(false)
-//  // Open the DB. This DB should have the same state as if the earlier strictFS operations and
-//  // db.Close() were not called.
-//  db := Open(..., &Options{FS: strictFS})
+//
+//	strictFS := NewStrictMem()
+//	db := Open(..., &Options{FS: strictFS})
+//	// Do and commit various operations.
+//	...
+//	// Prevent any more changes to finalized state.
+//	strictFS.SetIgnoreSyncs(true)
+//	// This will finish any ongoing background flushes, compactions but none of these writes will
+//	// be finalized since syncs are being ignored.
+//	db.Close()
+//	// Discard unsynced state.
+//	strictFS.ResetToSyncedState()
+//	// Allow changes to finalized state.
+//	strictFS.SetIgnoreSyncs(false)
+//	// Open the DB. This DB should have the same state as if the earlier strictFS operations and
+//	// db.Close() were not called.
+//	db := Open(..., &Options{FS: strictFS})
 func NewStrictMem() *MemFS {
 	return &MemFS{
 		root: &memNode{
@@ -163,6 +164,7 @@ func (y *MemFS) iterate(node *memNode,
 //   - "/", "foo", false
 //   - "/foo/", "bar", false
 //   - "/foo/bar/", "x", true
+//
 // Similarly, walking "/y/z/", with a trailing slash, will result in 3 calls to f:
 //   - "/", "y", false
 //   - "/y/", "z", false
@@ -323,6 +325,16 @@ func (y *MemFS) open(fullname string, allowEmptyName bool) (File, error) {
 // Open implements FS.Open.
 func (y *MemFS) Open(fullname string, opts ...OpenOption) (File, error) {
 	return y.open(fullname, false /* allowEmptyName */)
+}
+
+// Open implements FS.OpenReadWrite.
+func (y *MemFS) OpenReadWrite(fullname string, opts ...OpenOption) (File, error) {
+	f, err := y.Open(fullname)
+	if err != nil {
+		return nil, err
+	}
+	mf := f.(*memFile)
+	return &memFile{n: mf.n, fs: y, write: true, wpos: len(mf.n.mu.data)}, nil
 }
 
 // OpenForAppend implements FS.OpenForAppend.


### PR DESCRIPTION
This let's vfs implement pebble.VFS which means dragonboat can use the latest version of pebble.

I plan to send this change upstream as well, but doing it here first to unblock my work upgrading us.